### PR TITLE
Fix regression introduced by removing `nrfxlib` patch.  Add `[patch.crates-io]` entry.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ nrf9160-hal = "0.15.1"
 nrfxlib = "0.6.0"
 tinyrlibc = "0.2.2"
 
+# This patch fixes a dependency collison between different versions of nrf9160-pac
+# The hal uses 0.11.0 and nrfxlib uses 0.2.1 of the pac -> rust-lld: error: duplicate symbol: DEVICE_PERIPHERALS
+[patch.crates-io]
+nrfxlib = { git = "https://github.com/folkertdev/nrfxlib", rev = "a5672efcaeaf8f4485d755e086cb36c00f79ca78" }
+
 [dev-dependencies]
 defmt-test = "0.3.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 use defmt_rtt as _; // global logger
 
-// TODO(5) adjust HAL import
 use nrf9160_hal as _; // memory layout
 
 use panic_probe as _;


### PR DESCRIPTION
I didn't realize why the nrfxlib patch from a git repo was there until I tried to build the `modem_serial` example.  I added it back as an `[patch/crates-io]` entry and it fixes everything.