### PR TITLE
Fix PAC dependency collision by switching to main branch of nrf-rs/nr…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tinyrlibc = "0.3.0"
 # This patch fixes a dependency collison between different versions of nrf9160-pac
 # The hal uses 0.11.0 and nrfxlib uses 0.2.1 of the pac -> rust-lld: error: duplicate symbol: DEVICE_PERIPHERALS
 [patch.crates-io]
-nrfxlib = { git = "https://github.com/folkertdev/nrfxlib", rev = "a5672efcaeaf8f4485d755e086cb36c00f79ca78" }
+nrfxlib = { git = "https://github.com/nrf-rs/nrfxlib" }
 
 [dev-dependencies]
 defmt-test = "0.3.0"


### PR DESCRIPTION
nrf9160-hal is set to v0.16.0 which uses v0.12.2 of the PAC.  The current nrfxlib patch uses PAC v0.11.0.  Change the patch to the main branch of the official nrf-rs/nrfxlib repo as it uses PAC v0.12. 